### PR TITLE
Allow for multiple fingerprints in XML Security

### DIFF
--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -55,9 +55,24 @@ module SamlIdp
         # check cert matches registered idp cert
         fingerprint = fingerprint_cert(cert)
         sha1_fingerprint = fingerprint_cert_sha1(cert)
-        plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
 
-        if fingerprint != plain_idp_cert_fingerprint && sha1_fingerprint != plain_idp_cert_fingerprint
+        fingerprint_validation = false
+
+        if idp_cert_fingerprint.is_a?(Array)
+          idp_cert_fingerprint.each do |idp_cert_fingerprint_single|
+            plain_idp_cert_fingerprint = idp_cert_fingerprint_single.gsub(/[^a-zA-Z0-9]/,"").downcase
+            if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint != plain_idp_cert_fingerprint
+              fingerprint_validation = true
+            end
+          end
+        else
+          plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
+          if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint != plain_idp_cert_fingerprint
+            fingerprint_validation = true
+          end
+        end
+
+        if fingerprint_validation == false
           return soft ? false : (raise ValidationError.new("Fingerprint mismatch"))
         end
 

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -58,15 +58,8 @@ module SamlIdp
 
         fingerprint_validation = false
 
-        if idp_cert_fingerprint.is_a?(Array)
-          idp_cert_fingerprint.each do |idp_cert_fingerprint_single|
-            plain_idp_cert_fingerprint = idp_cert_fingerprint_single.gsub(/[^a-zA-Z0-9]/,"").downcase
-            if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint != plain_idp_cert_fingerprint
-              fingerprint_validation = true
-            end
-          end
-        else
-          plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
+        [idp_cert_fingerprint].flatten.each do |idp_cert_fingerprint_single|
+          plain_idp_cert_fingerprint = idp_cert_fingerprint_single.gsub(/[^a-zA-Z0-9]/,"").downcase
           if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint != plain_idp_cert_fingerprint
             fingerprint_validation = true
           end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -60,7 +60,7 @@ module SamlIdp
 
         [idp_cert_fingerprint].flatten.each do |idp_cert_fingerprint_single|
           plain_idp_cert_fingerprint = idp_cert_fingerprint_single.gsub(/[^a-zA-Z0-9]/,"").downcase
-          if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint != plain_idp_cert_fingerprint
+          if fingerprint == plain_idp_cert_fingerprint || sha1_fingerprint == plain_idp_cert_fingerprint
             fingerprint_validation = true
           end
         end


### PR DESCRIPTION
This allows us to 'rotate' certs by adding new ones before the old ones expire to provide for uninterrupted service.

i.e. upcoming kyriba service provider cert refresh on 5-16-20